### PR TITLE
Minor grammatical changes

### DIFF
--- a/Overview.html
+++ b/Overview.html
@@ -262,7 +262,7 @@
 			<div class="example-bar">
 				<h3>Example responsibilities</h3>
 				<ul>
-					<li><b>Marketing</b> - Ensuring good accessibility practices within the brand or design guidelines.</li>
+					<li><b>Marketing</b> - Ensure good accessibility practices within the brand or design guidelines.</li>
 					<li><b>Quality assurance</b> - Test for and track accessibility issues within the code.</li>
 					<li><b>Development</b> - Maintain code libraries with accessible components.</li>
 					<li><b>Purchasing</b> - Ensure that organizational accessibility policy is incorporated within procurement processes.</li>
@@ -285,12 +285,12 @@
 				</li>
 				<li><span class="f_panelHead">Communicate within the project and organization who the responsible parties are.</span>
 					<div>
-						<p>Communicate who to take accessibility issues to and also highlight the ongoing commitment to accessibility. For wider organizational communication aim to inform key members of management and teams involved in website development activities.</p>
+						<p>Communicate whom to take accessibility issues to and also highlight the ongoing commitment to accessibility. For wider organizational communication aim to inform key members of management and teams involved in website development activities.</p>
 					</div>
 				</li>
 				<li><span class="f_panelHead">Ensure any third-party providers are aware of your accessibility requirements and your expectations.</span>
 					<div>
-						<p>If the website being created, or part of it, such as the visual design, is outsourced to an external company, make them aware of your accessibility policy. Ultimately you, as the purchaser, will still hold responsibility for website accessibility. Responsibility in this case means clear communication of what you expect in terms of accessibility and any additional accessibility acceptance testing.</p>
+						<p>If the website being created or a part of it, such as the visual design, is outsourced to an external company, make them aware of your accessibility policy. Ultimately you, as the purchaser, still hold responsibility for website accessibility. Responsibility in this case means clear communication of what you expect in terms of accessibility and any additional accessibility acceptance testing.</p>
 					</div>
 				</li>
 				<li><span class="f_panelHead">Assign responsibility for each jurisdictional region your website spans.</span>


### PR DESCRIPTION
In "Establish Roles and Responsibilities," (1) made verbs in example responsibilities parallel; (2) in key action 3 description, changed "who" to "whom"; (3) cleaning up clauses in key action 4 description.  

Also, while I did not change it, the wording of key action 2 ("Assign responsibility to other organizational areas that impact on the provision of accessible websites") strikes me as awkward.  Can "impact on" be changed to just "impact"?
