### PR TITLE
Example should mention WCAG version (2.0) and link to the Guideline, …

### DIFF
--- a/pol.html
+++ b/pol.html
@@ -300,7 +300,7 @@
 		<h3>Examples</h3>
 		<h4 class="no-display">Simple example of referencing WCAG</h4>
 		<div class="drop-shadow">
-			<p>ACME Inc. seeks to make sure our website conforms to <abbr title="Worldwide Web Consortium">W3C</abbr> <abbr title="Web Accessibility Initiative">WAI</abbr> <a href="/WAI/intro/wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr></a> Level AA.</p>
+			<p>ACME Inc. seeks to make sure our website conforms to <abbr title="Worldwide Web Consortium">W3C</abbr> <abbr title="Web Accessibility Initiative">WAI</abbr> <a href="/TR/WCAG20/"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr></a> 2.0 Level AA.</p>
 		</div>
 		<h4 class="no-display">Example of reference to WCAG and ATAG</h4>
 		<div class="drop-shadow">


### PR DESCRIPTION
…not to the intro text, imho
