### PR TITLE
Minor comma adjustments in "Next Steps"

### DIFF
--- a/improving.html
+++ b/improving.html
@@ -314,7 +314,7 @@
 
 
 			  <h2 id="analysis">Next steps: Analysis of Findings</h2>
-				<p>The previous steps will help you remedy immediately apparent barriers but maintaining this level of accessibility may require broader changes or added mechanisms. Reflecting on what caused each barrier can help in understanding what additional changes might be required. For example, poor link text may have been caused by content managers with insufficient awareness of accessibility issues, or video production process may neglect the creation of transcripts.</p>
+				<p>The previous steps will help you remedy immediately apparent barriers, but maintaining this level of accessibility may require broader changes or added mechanisms. Reflecting on what caused each barrier can help in understanding what additional changes might be required. For example, poor link text may have been caused by content managers with insufficient awareness of accessibility issues or video production process may neglect the creation of transcripts.</p>
 				<p>Addressing these issues is likely to be more involved than fixing immediate barriers. You might need to consider additional training and identify who would most benefit, changing processes to introduce appropriate quality assurance checks, reviewing company policies, such as procurement, to incorporate accessibility, or development infrastructure to ensure accessibility is baked in by default.</p>
 
 				<h3>Key actions</h3>


### PR DESCRIPTION
I've noticed a number of places with unneeded commas, but have ignored them because they are in longish sentences.  However, here are comma is missing, so I've added it and gone ahead and deleted one on those unnecessary ones.

Also, I got lost at this point in the second sentence of the second paragraph: "reviewing company policies, such as procurement, to incorporate accessibility, or development infrastructure to ensure accessibility is baked in by default."  It needs work, but I'm unsure what you're trying to say at that point.  It's great up until that point.
