### PR TITLE
undo "subhead" style

### DIFF
--- a/improving.html
+++ b/improving.html
@@ -76,7 +76,7 @@
 		  <p><strong>Status:</strong> This is an in-progress, unapproved draft.</p>
 		</div>
 
-	  <h1>Web Accessibility First Aid: <span class="subhead">Approaches for Interim Repairs</span></h1>
+	  <h1>Web Accessibility First Aid: <br/>Approaches for Interim Repairs</h1>
 	  <div id="contents">
 	    <h2>Page contents</h2>
 	    <ul>


### PR DESCRIPTION
For this doc, I think the part of the title after the colon is very important for understanding what it's about. -- so I think it should not be tiny. I'm OK with it being on the same line or next line...
