### PR TITLE
Update improving.html

### DIFF
--- a/improving.html
+++ b/improving.html
@@ -111,7 +111,7 @@
 	<p>If there is a need, more in-depth introductions and background is provided in <a href="https://www.w3.org/WAI/intro/people-use-web/">How People with Disabilities Use the Web</a>. Specifically the <a href="https://www.w3.org/WAI/intro/people-use-web/principles">Accessibility Principles</a> section of the resource introduces the accessibility requirements and guidelines.</p>
 
 	<h2 id="explore">What are the Issues?</h2>
-	<p>If you already know the specific issues you need to address, you can skip this section. If you are starting to address accessibility without this information, the following manual helps you get a rough idea of the current situation on your website:</p>
+	<p>If you already know the specific issues you need to address, you can skip this section. If you are starting to address accessibility without background, the following manual helps you get a rough idea of the current situation on your website:</p>
 	<ul>
 		<li><a href="https://www.w3.org/WAI/eval/preliminary.html">Easy Checks &mdash; A First Review of Web Accessibility</a> &mdash; Simple checks that can be carried out by anyone, regardless of technical skills and accessibility knowledge.</li>
 	</ul>
@@ -120,7 +120,7 @@
 		<li><a href="https://www.w3.org/WAI/ER/tools/">List of Web Accessibility Evaluation Tools</a> &mdash; Customizable list that allows you to search for different types of tools.</li>
 	</ul>
 	<p>Note: some web accessibility evaluation tools may be complex and confusing to use for people new to accessibility. They typically only check a subset of issues, and may be prone to misleading results.</p>
-	<p>To get a complete picture of the situation, a comprehensive evaluation will likely be needed. Such thorough evaluations require accessibility expertise. The following resources help you evaluate your website:</p>
+	<p>To get a complete picture of the situation, a comprehensive evaluation may be needed. Such thorough evaluations require accessibility expertise. The following resources help you evaluate your website:</p>
 	<ul>
 		<li><a href="https://www.w3.org/WAI/eval/conformance.html">Website Accessibility Conformance Evaluation Methodology (WCAG-EM)</a> &mdash; Provides a structured approach to help evaluate websites for accessibility.</li>
 		<li><a href="https://www.w3.org/WAI/eval/report-tool/">WCAG-EM Report Tool</a> &mdash; Free online tool to help create evaluation reports following the WCAG-EM procedure.</li>

--- a/improving.html
+++ b/improving.html
@@ -92,49 +92,49 @@
 	  </div>
 
 	<h2 id="intro" class="no-display">Introduction</h2>
-	<p>Are you in a situation where you need to urgently address accessibility in an on-going website development project? This resource provides guidance and pointers to resources, to help you address the most critical issues. A more comprehensive guide to help you address accessibility more thoroughly throughout the design and development process is provided in <a href="https://www.w3.org/WAI/impl/Overview">Planning and Managing Web Accessibility</a>.</p>
+	<p>Do you need to urgently address accessibility in an on-going website development project? This guide provides guidance and pointers to resources to help you address the most critical issues. A more comprehensive guide to help you address accessibility more thoroughly throughout the design and development process is provided in <a href="https://www.w3.org/WAI/impl/Overview">Planning and Managing Web Accessibility</a>.</p>
 
 	<h2 id="resources">Important Resources</h2>
 	<p>The following resources may be helpful right away to the designers and developers in your team:</p>
 	<ul>
 		<li><a href="https://www.w3.org/WAI/gettingstarted/tips/">Tips for Getting Started</a> &mdash; Practical considerations with examples for designing, writing, and developing accessible web content.</li>
-		<li><a href="https://www.w3.org/WAI/tutorials/">Web Accessibility Tutorials</a> &mdash; More comprehensive information on specific topics with guidance on addressing the accessibility requirements.</li>
+		<li><a href="https://www.w3.org/WAI/tutorials/">Web Accessibility Tutorials</a> &mdash; Detailed information on specific topics with guidance on addressing accessibility requirements.</li>
 		<li><a href="https://www.w3.org/WAI/WCAG20/quickref/">How to Meet WCAG 2.0</a> &mdash; A customizable quick reference to Web Content Accessibility Guidelines (WCAG) 2.0.</li>
 	</ul>
 
 	<h2 id="understand">What is Accessibility?</h2>
 	<p>If you are new to accessibility, it is often helpful to first get a basic idea of the topic. Here are some quick introductions:</p>
 	<ul>
-		<li><a href="https://www.w3.org/standards/webdesign/accessibility">W3C - Accessibility</a> &mdash; Introduces the essential concepts, rationale, and resources.</li>
-		<li><a href="https://www.w3.org/WAI/perspectives">Web Accessibility Perspectives</a> &mdash; Short videos that introduce accessibility features and their benefits for everyone.</li>
+		<li><a href="https://www.w3.org/standards/webdesign/accessibility">W3C - Accessibility</a> &mdash; Introduces essential concepts, rationale, and resources.</li>
+		<li><a href="https://www.w3.org/WAI/perspectives">Web Accessibility Perspectives</a> &mdash; Short non-technical videos that introduce accessibility features and their benefits for everyone.</li>
 	</ul>
 	<p>If there is a need, more in-depth introductions and background is provided in <a href="https://www.w3.org/WAI/intro/people-use-web/">How People with Disabilities Use the Web</a>. Specifically the <a href="https://www.w3.org/WAI/intro/people-use-web/principles">Accessibility Principles</a> section of the resource introduces the accessibility requirements and guidelines.</p>
 
 	<h2 id="explore">What are the Issues?</h2>
-	<p>If you already know of the specific issues you need to address, you can skip this section. If you are starting to address accessibility from new, the following manual helps you get a rough idea of the current situation on your website:</p>
+	<p>If you already know the specific issues you need to address, you can skip this section. If you are starting to address accessibility without this information, the following manual helps you get a rough idea of the current situation on your website:</p>
 	<ul>
 		<li><a href="https://www.w3.org/WAI/eval/preliminary.html">Easy Checks &mdash; A First Review of Web Accessibility</a> &mdash; Simple checks that can be carried out by anyone, regardless of technical skills and accessibility knowledge.</li>
 	</ul>
-	<p>Some web accessibility evaluation tools may help you further explore the accessibility on your website. For example, some evaluation tools can assist you by "generating reports of evaluation results", "providing step-by-step evaluation guidance", "displaying information within web pages", and "modifying the presentation of web pages", to help you explore and understand some of the issues:</p>
+	<p>Some web accessibility evaluation tools may help you further explore the accessibility on your website:</p>
 	<ul>
 		<li><a href="https://www.w3.org/WAI/ER/tools/">List of Web Accessibility Evaluation Tools</a> &mdash; Customizable list that allows you to search for different types of tools.</li>
 	</ul>
-	<p>Note that some web accessibility evaluation tools may be complex and confusing to use for people new to accessibility. They typically only check a subset of issues, and may be prone to misleading results.</p>
-	<p>Following these explorations, a more comprehensive evaluation may be needed to get a full picture of the situation. Such thorough evaluations require accessibility expertise. The following resources help you evaluate your website:</p>
+	<p>Note: some web accessibility evaluation tools may be complex and confusing to use for people new to accessibility. They typically only check a subset of issues, and may be prone to misleading results.</p>
+	<p>To get a complete picture of the situation, a comprehensive evaluation will likely be needed. Such thorough evaluations require accessibility expertise. The following resources help you evaluate your website:</p>
 	<ul>
 		<li><a href="https://www.w3.org/WAI/eval/conformance.html">Website Accessibility Conformance Evaluation Methodology (WCAG-EM)</a> &mdash; Provides a structured approach to help evaluate websites for accessibility.</li>
 		<li><a href="https://www.w3.org/WAI/eval/report-tool/">WCAG-EM Report Tool</a> &mdash; Free online tool to help create evaluation reports following the WCAG-EM procedure.</li>
 	</ul>
 
 	<h2 id="scope">What is your Scope?</h2>
-	<p>You may not be able to address all the issues on every part of your website at once. Consider which parts you may need to improve right away, and which to address in later stages. Consider the following:</p>
+	<p>You may not be able to address all the issues on every part of your website at once. To determine which parts you may need to improve right away, and which to address in later stages, consider the following:</p>
 	<ul>
-		<li><strong>Key processes</strong>, such as registration, purchase, or checkout processes. Include all steps in each of these processes.</li>
-		<li><strong>Key content</strong>, such as frequently accessed content and content that is particularly relevant to people with disabilities.</li>
+		<li><strong>Key tasks</strong>, such as registration, purchase, or checkout processes. Include all steps in each of these flows.</li>
+		<li><strong>Key content</strong>, such as frequently accessed content and content that is relevant to people with disabilities.</li>
 		<li><strong>Reported content</strong>, that has known barriers; for example, from user comments submitted through the website feedback form.</li>
 		<li><strong>In-development content</strong>, such as areas of the website that are currently being redesigned, to avoid the creation of new barriers.</li>
 	</ul>
-	<p>Within your scope of repair, consider prioritizing what you repair first by:</p>
+	<p>Within your scope of repair, consider prioritizing what you repair first by focusing on:</p>
 	<ul>
 		<li><strong>High-impact repairs</strong>
 			<ul>
@@ -147,28 +147,27 @@
 		<li><strong>Low-effort repairs</strong>
 			<ul>
 				<li>Require less time, cost, or skills to repair</li>
-				<li>Requires less regression testing and validation by others</li>
-				<li>Requires less testing with end-users (eg. user experience)</li>
+				<li>Requires less testing and validation</li>
 			</ul>
 		</li>
 	</ul>
 
-	<h2 id="target">What is your Target?</h2>
+	<h2 id="target">What is your Target Level of Accessibility?</h2>
 	<p>The generally accepted target for accessibility is <a href="https://www.w3.org/WAI/intro/wcag">Web Content Accessibility Guidelines (WCAG) 2.0</a> Level AA. This may already be the standard specified in your organizational policy or it may be the legal requirement for your website.</p>
-	<p>You may need to define a multi-tiered targets with different dates for different levels. For example, meet particular WCAG 2.0 success criteria in the next release, and meet all Level A and Level AA success criteria in the following release.</p>
+	<p>You may need to define a phased approach with different dates for different levels. For example, meet particular WCAG 2.0 success criteria in the next release, and meet all Level A and Level AA success criteria in the following release.</p>
 	<p>Note that in some cases, some Level AAA success criteria may be fairly easy to meet. For example, refining appropriate link text (2.4.9, Level AA) and heading structure (2.4.10, Level AAA) may be easy to address together when revising content.</p>
 
 	<h2 id="repair">What is your Strategy?</h2>
-	<p>Consider some of the following aspects to help you implement the accessibility repairs:</p>
+	<p>Consider the following tips to help you implement accessibility repairs:</p>
 	<ul>
-		<li><strong>Leverage the different skills in your team</strong> &mdash; While many tasks will be for developers, other people can do other tasks; for example, designers can select better colors and content authors can improve the wording of links, headings, and text alternatives. The resource <a href="https://www.w3.org/WAI/eval/reviewteams.html">Using Combined Expertise to Evaluate Web Accessibility</a> may be helpful.</li>
+		<li><strong>Leverage the different skills in your team</strong> &mdash; While many tasks will be for developers, other roles have plenty to contribute. For example, designers can select better colors and content authors can improve the wording of links, headings, and text alternatives. The resource <a href="https://www.w3.org/WAI/eval/reviewteams.html">Using Combined Expertise to Evaluate Web Accessibility</a> may be helpful.</li>
 		<li><strong>Communicate requirements across your team</strong> &mdash; Ensure that everyone involved in repairs understands the basics of web accessibility and the specific requirements they need to address. Distribute the <a href="resources">Important Resources</a> to the relevant members of your team.</li>
 		<li><strong>Validate solutions as early as possible</strong> &mdash; Ensure that any solutions adequately address the issues raised to avoid implementing changes that do not work in practice. If at all possible, it is important to involve people with disabilities in such validation. The resources <a href="https://www.w3.org/WAI/users/involving">Involving Users in Web Projects for Better, Easier Accessibility</a> and <a href="https://www.w3.org/WAI/eval/users.html">Involving Users in Evaluating Web Accessibility</a> provide more background.</li>
 		<li><strong>Optimize your Tools</strong> &mdash; Explore and configure accessibility settings in the authoring tools you use to create web content, such as your content management system (CMS). The resources <a href="https://www.w3.org/WAI/eval/selectingtools">Selecting Web Accessibility Evaluation Tools</a> and <a href="https://www.w3.org/WAI/impl/software">Selecting and Using Authoring Tools for Web Accessibility</a> may be helpful.</li>
 	</ul>
 
 	<h2 id="plan">Longer Term: Planning and Managing</h2>
-	<p>With this guidance you may have addressed some of the most critical web accessibility issues on your website but probably needed to leave out many more. It is now essential to integrate accessibility throughout the design and development process. The <a href="https://www.w3.org/WAI/impl/Overview">Planning and Managing Web Accessibility</a> guide help you to develop a plan of accessibility implementation tasks and considerations.</p>
+	<p>Once you have addressed some of the most critical web accessibility issues on your website and begun to address the rest, it is essential you plan to integrate accessibility throughout the design and development process. The <a href="https://www.w3.org/WAI/impl/Overview">Planning and Managing Web Accessibility</a> guide can help you develop that plan.</p>
 
 		<aside class="side-box contribute" role="complementary">
 		  <h2 class="heading">Help improve this page</h2>


### PR DESCRIPTION
Minor simplification or clarifications throughout
Typo section 2
Clarified videos are non-technical in section 3
Changed idiom? "from new" to "without this information" in section 4
Removed sentences with series of "examples" in section 4 above list of web a11y eval tools to simplify and shorten
Reworked sentence with "following these explorations" to simplify and clarify in section 4
Replaced one of two "considers" in close proximity in section 5
Replaced 2 of 3 "processes" in close proximity in section 5
Removed "requires less testing with end- users etc. as I suggested in https://github.com/w3c/wai-planning-and-implementation/issues/89
Clarified "target" and multi-tiered approach in section 7 (this removed typo "need to define A")
Changed "aspects" to "tips" since we don't define them as aspects of anything particular
Removed one of two "Other" in close proximity in section 8 and clarified sentence
Simplified last section.
Added "can" to fix typo in last sentence.
